### PR TITLE
Pluralize and singularize issue for status

### DIFF
--- a/EFCore.Pluralizer.Test/PluralizerTests.cs
+++ b/EFCore.Pluralizer.Test/PluralizerTests.cs
@@ -4,12 +4,22 @@ namespace Bricelam.EntityFrameworkCore.Design
 {
     public class PluralizerTests
     {
-        [Fact]
-        public void Pluralize_works()
-            => Assert.Equal("Tests", new Pluralizer().Pluralize("Test"));
+        [Theory]
+        [InlineData("Tests", "Test")]
+        [InlineData("Statuses", "Status")]
+        [InlineData("ItemStatuses", "ItemStatus")]
+        [InlineData("Statuses", "Statuses")]
+        [InlineData("ItemStatuses", "ItemStatuses")]
+        public void Pluralize_works(string result, string input)
+            => Assert.Equal(result, new Pluralizer().Pluralize(input));
 
-        [Fact]
-        public void Singularize_works()
-            => Assert.Equal("Test", new Pluralizer().Singularize("Tests"));
+        [Theory]
+        [InlineData("Test", "Tests")]
+        [InlineData("Status", "Statuses")]
+        [InlineData("ItemStatus", "ItemStatuses")]
+        [InlineData("Status", "Status")]
+        [InlineData("ItemStatus", "ItemStatus")]
+        public void Singularize_works(string result, string input)
+            => Assert.Equal(result, new Pluralizer().Singularize(input));
     }
 }

--- a/EFCore.Pluralizer/Pluralizer.cs
+++ b/EFCore.Pluralizer/Pluralizer.cs
@@ -294,7 +294,7 @@ namespace Bricelam.EntityFrameworkCore.Design
             { "sinus", "sinus" },
             { "coitus", "coitus" },
             { "plexus", "plexus" },
-            { "status", "status" },
+            { "status", "statuses" },
             { "hiatus", "hiatus" },
             { "afreet", "afreeti" },
             { "afrit", "afriti" },
@@ -502,7 +502,7 @@ namespace Bricelam.EntityFrameworkCore.Design
                 return prefixWord + suffixWord;
 
             // handle irregular plurals, e.g. "ox" -> "oxen"
-            if (_irregularPluralsList.TryGetValue(suffixWord, out var plural))
+            if (_irregularPluralsList.TryGetValue(suffixWord.ToLowerInvariant(), out var plural))
                 return prefixWord + plural;
 
             // handle irregular inflections for common suffixes, e.g. "mouse" -> "mice"


### PR DESCRIPTION
Hi,

I am using your package with EF Core but I have a problem with few entities which have "status" in their names. I added a few test cases and fixed a problem when the word to pluralize is status. But in order to fix the singularize and pluralize issue for entities like ItemStatus maybe the easiest way would be to change the method GetSuffixWord to split the entities by capital letter. I don't have much time to deep dive into the code and to investigate this issue further more so please can you help me? Thanks in advance